### PR TITLE
improve docs for encryption

### DIFF
--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -9,7 +9,7 @@ With site config files in public repositories being accessible by anyone, it's i
 Imagine that you want to store a reCaptcha secret of `1q2w3e4r`. Hit the following endpoint with a GET request:
 
 ```
-https://api.staticman.net/v3/encrypt/1q2w3e4r
+https://{STATICMAN_BASE_URL}/v3/encrypt/1q2w3e4r
 ```
 
 Then add the result to the config file.


### PR DESCRIPTION
Resolve #16.  I've chosen `{STATICMAN_BASE_URL}` instead of `*.herokuapp.com` due to option 2 of step 2 of the quick start guide: https://github.com/eduardoboucas/staticman.net/blob/d1174fed6813a79f5ab002e01b3a77cfa47cea60/docs/getting-started.md#option-2-deploy-to-your-own-infrastructure